### PR TITLE
Feat: 로그인 / 회원 가입 공통 푸터 구현

### DIFF
--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -1,0 +1,91 @@
+import { TextBox } from '@components/text-box';
+import { Layout } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+
+export const Footer = () => {
+  return (
+    <StyledLayout>
+      <Container>
+        <HrefContainer>
+          <TextBox
+            typography="body5"
+            color={'black900'}
+            textAlign="center"
+            fontWeight={'400'}
+            cursor="pointer"
+          >
+            <a
+              href="https://terms.yanolja.com/basicTerms
+            "
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              이용약관
+            </a>
+          </TextBox>
+          <TextBox
+            typography="body5"
+            color={'black900'}
+            textAlign="center"
+            fontWeight={'700'}
+          >
+            |
+          </TextBox>
+          <TextBox
+            typography="body5"
+            color={'black900'}
+            textAlign="center"
+            fontWeight={'400'}
+            cursor="pointer"
+          >
+            <a
+              href="https://terms.yanolja.com/privacyUse"
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              개인정보 처리방침
+            </a>
+          </TextBox>
+        </HrefContainer>
+        <TextContainer>
+          <TextBox
+            typography="body5"
+            color={'black600'}
+            textAlign="center"
+            fontWeight={'400'}
+          >
+            (주) 야놀자 Copyright © 2005-2023 Yanolja Co., Ltd. All rights
+            reserved.
+          </TextBox>
+        </TextContainer>
+      </Container>
+    </StyledLayout>
+  );
+};
+
+const StyledLayout = styled(Layout)`
+  width: 100%;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  gap: 4px;
+`;
+
+const HrefContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 9.5px;
+`;
+
+const TextContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 9.5px;
+`;

--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -1,3 +1,4 @@
+import { colors } from '@/constants/colors';
 import { TextBox } from '@components/text-box';
 import { Layout } from 'antd';
 import React from 'react';
@@ -64,6 +65,7 @@ export const Footer = () => {
 
 const StyledLayout = styled(Layout)`
   width: 100%;
+  background-color: ${colors.midGray};
 `;
 
 const Container = styled.div`

--- a/src/components/layout/side-bar/accommodation-list/index.tsx
+++ b/src/components/layout/side-bar/accommodation-list/index.tsx
@@ -1,4 +1,4 @@
-import TextBox from '@components/text-box';
+import { TextBox } from '@components/text-box';
 import { Button } from 'antd';
 import styled from 'styled-components';
 import { colors } from '@/constants/colors';

--- a/src/components/layout/side-bar/navigation/index.tsx
+++ b/src/components/layout/side-bar/navigation/index.tsx
@@ -1,6 +1,6 @@
 import { colors } from '@/constants/colors';
 import { navigationMap } from '@/constants/navigation';
-import TextBox from '@components/text-box';
+import { TextBox } from '@components/text-box';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { StyledNavItemProps } from './type';

--- a/src/components/layout/side-bar/signout-btn/index.tsx
+++ b/src/components/layout/side-bar/signout-btn/index.tsx
@@ -1,5 +1,5 @@
 import { LogoutOutlined } from '@ant-design/icons';
-import TextBox from '@components/text-box';
+import { TextBox } from '@components/text-box';
 import styled from 'styled-components';
 
 export const SignOutBtn = () => {

--- a/src/components/layout/side-bar/user-profile/index.tsx
+++ b/src/components/layout/side-bar/user-profile/index.tsx
@@ -1,6 +1,6 @@
 import { Button, Space } from 'antd';
 import styled from 'styled-components';
-import TextBox from '@components/text-box';
+import { TextBox } from '@components/text-box';
 import { colors } from '@/constants/colors';
 import { StyledSpaceProps } from './type';
 

--- a/src/pages/sign-in-agreement/index.tsx
+++ b/src/pages/sign-in-agreement/index.tsx
@@ -1,3 +1,25 @@
+import { Footer } from '@components/layout/footer';
+import { Layout } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
 export const SignInAgreement = () => {
-  return <div>sign-in-agreement page</div>;
+  return (
+    <StyledLayout>
+      <StyledContent>sign-in-agreement-page</StyledContent>
+      <Footer />
+    </StyledLayout>
+  );
 };
+const StyledLayout = styled(Layout)`
+  max-width: 100vw;
+  background-color: white;
+`;
+
+const StyledContent = styled(Layout.Content)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  height: 666px;
+`;

--- a/src/pages/sign-in/index.tsx
+++ b/src/pages/sign-in/index.tsx
@@ -1,3 +1,25 @@
+import { Layout } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { Footer } from '@components/layout/footer';
 export const SignIn = () => {
-  return <div>sign-in page</div>;
+  return (
+    <StyledLayout>
+      <StyledContent>sign-in-page</StyledContent>
+      <Footer />
+    </StyledLayout>
+  );
 };
+const StyledLayout = styled(Layout)`
+  max-width: 100vw;
+  background-color: white;
+`;
+
+const StyledContent = styled(Layout.Content)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  height: 666px;
+`;

--- a/src/pages/sign-up/index.tsx
+++ b/src/pages/sign-up/index.tsx
@@ -1,3 +1,25 @@
+import { Footer } from '@components/layout/footer';
+import { Layout } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
 export const SignUp = () => {
-  return <div>sign-up page</div>;
+  return (
+    <StyledLayout>
+      <StyledContent>sign-up-page</StyledContent>
+      <Footer />
+    </StyledLayout>
+  );
 };
+const StyledLayout = styled(Layout)`
+  max-width: 100vw;
+  background-color: white;
+`;
+
+const StyledContent = styled(Layout.Content)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+  height: 666px;
+`;


### PR DESCRIPTION
### ⛳️ Task
close #16 
- [x] 로그인 / 회원 가입 공통 푸터 구현

### ✍️ Note
로그인 / 회원 가입 페이지 내 공통으로 들어가는 푸터 구현 완료입니다!

해당하는 페이지들은 StyledLayout의 max-width: 100vw로 설정하였습니다.

피그마에서 height값이 고정되어 있어 스크롤이 발생하는 데 이 부분은 어떻게 해야할 지 잘 모르겠어서 일단 요구 사항대로 구현하였습니다!


### ⚡️ Test

### 📸 Screenshot
![image](https://github.com/Upjuyanolja/Upjuyanolja_FE/assets/37584686/b83bd1cc-ecc7-4d94-80dd-7bc54008aeab)


### 📎 Reference
