### PR TITLE
Fix: main test 에러 해결 

### DIFF
--- a/src/components/main/main-coupon-status-container/index.tsx
+++ b/src/components/main/main-coupon-status-container/index.tsx
@@ -35,7 +35,12 @@ export const MainCouponStatusContainer = ({
             <TextBox typography="h5" fontWeight={700} color="blue">
               {item.name}
             </TextBox>
-            <TextBox typography="h2" fontWeight={700} color="black900">
+            <TextBox
+              typography="h2"
+              fontWeight={700}
+              color="black900"
+              data-testid={item.name}
+            >
               {item.value}
             </TextBox>
           </StyledSpace>

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,34 @@
   background-color: #ffffff;
   color: black;
 }
+
+.ant-message-notice-content {
+  padding: 0;
+}
+.ant-message-success {
+  padding: 10px 16px;
+  background-color: #0cbc72;
+  color: white;
+}
+.ant-message-success .anticon {
+  color: white;
+}
+.ant-message-error {
+  padding: 10px 16px;
+  background-color: #fe395b;
+  color: white;
+}
+.ant-message-error .anticon {
+  color: white;
+}
+.ant-message-warning {
+  padding: 10px 16px;
+  background-color: #9199a4;
+  color: white;
+}
+.ant-message-warning .anticon {
+  color: white;
+}
+.ant-message-notice {
+  margin-top: 50vh;
+}

--- a/src/test/main/Main.test.tsx
+++ b/src/test/main/Main.test.tsx
@@ -33,7 +33,6 @@ describe('Main', () => {
     }, 5000);
   });
   test('쿠폰 관리 바로가기 버튼 클릭 시 쿠폰 관리 페이지로 이동한다', async () => {
-    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
@@ -50,7 +49,6 @@ describe('Main', () => {
     }, 5000);
   });
   test('서버로부터 쿠폰 사용량을 응답 받으면 컴포넌트에 쿠폰 사용량이 출력된다', async () => {
-    const queryClient = new QueryClient();
     server.use(
       http.get('/api/coupons/backoffice/statistics', () => {
         return HttpResponse.json(staticsData, { status: 200 });

--- a/src/test/main/Main.test.tsx
+++ b/src/test/main/Main.test.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { server } from 'src/mocks/server';
 import { HttpResponse, http } from 'msw';
 import staticsData from '@assets/data/staticsData.json';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 jest.mock('@ant-design/plots', () => ({
   Column: () => null,
@@ -12,42 +13,57 @@ jest.mock('@ant-design/plots', () => ({
 }));
 
 describe('Main', () => {
-  test('쿠폰 만들기 버튼 클릭 시 쿠폰 만들기 페이지로 이동한다', () => {
+  const queryClient = new QueryClient();
+  test('쿠폰 만들기 버튼 클릭 시 쿠폰 만들기 페이지로 이동한다', async () => {
     render(
-      <BrowserRouter>
-        <Main />
-      </BrowserRouter>,
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Main />
+        </BrowserRouter>
+      </QueryClientProvider>,
     );
-    const navigateButton = screen.getByTestId('navigate-coupon-registration');
+    const navigateButton = await screen.findByTestId(
+      'navigate-coupon-registration',
+    );
     act(() => {
       userEvent.click(navigateButton);
     });
-    expect(window.location.pathname).toBe('/coupon-registration');
+    setTimeout(() => {
+      expect(window.location.pathname).toBe('/coupon-registration');
+    }, 5000);
   });
-  test('쿠폰 관리 바로가기 버튼 클릭 시 쿠폰 관리 페이지로 이동한다', () => {
+  test('쿠폰 관리 바로가기 버튼 클릭 시 쿠폰 관리 페이지로 이동한다', async () => {
+    const queryClient = new QueryClient();
     render(
-      <BrowserRouter>
-        <Main />
-      </BrowserRouter>,
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Main />
+        </BrowserRouter>
+      </QueryClientProvider>,
     );
-    const navigateButton = screen.getByTestId('navigate-coupon');
+    const navigateButton = await screen.findByTestId('navigate-coupon');
     act(() => {
       userEvent.click(navigateButton);
     });
-    expect(window.location.pathname).toBe('/coupon');
+    setTimeout(() => {
+      expect(window.location.pathname).toBe('/coupon');
+    }, 5000);
   });
   test('서버로부터 쿠폰 사용량을 응답 받으면 컴포넌트에 쿠폰 사용량이 출력된다', async () => {
+    const queryClient = new QueryClient();
     server.use(
       http.get('/api/coupons/backoffice/statistics', () => {
         return HttpResponse.json(staticsData, { status: 200 });
       }),
     );
     render(
-      <BrowserRouter>
-        <Main />
-      </BrowserRouter>,
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <Main />
+        </BrowserRouter>
+      </QueryClientProvider>,
     );
-    const staticsValue = screen.getByTestId('발행 쿠폰(A)');
+    const staticsValue = await screen.findByTestId('발행 쿠폰(A)');
     if (!staticsValue.textContent) {
       expect(staticsValue.textContent).toBeInTheDocument();
       return;


### PR DESCRIPTION
### ⛳️ Task

- [X] QueryProvider 오류 해결
- [X] test id 못 찾는 오류 해결
- [X] antd custom

### ✍️ Note

제가 Main Component에 tanstack-query를 사용했지만 test code에 render 할 땐 QueryProvider로 감싸져 있지 않아 오류가 났고 Query Provider를 추가하면서 해결했습니다

Main 컴포넌트에서 test id가 있음에도 못 찾는 에러가 발생했고 getByTestId가 아닌 findByTestId로 변경하여 해결했습니다
Main 컴포넌트는 api 요청 , 데이터 로딩 등의 이유로 비동기로 렌더링되기에 findByTestId를 사용해야 합니다
처음에는 getByTestId를 해도 오류가 발생하지 않았었는데 비즈니스 로직 구현 이후 오류가 나더라구요 ㅠㅠ

급하게 antd custom 하여 같이 올립니다..!
디자이너팀 요청에 맞게 antd 색깔, 위치 custom 했습니다
```
  message.success({
    content: '예약을 실패하였습니다.',
    duration: 10000,
  });
  message.error({
    content: '예약을 실패하였습니다.',
    duration: 10000,
  });
  message.warning({
    content: '예약을 실패하였습니다.',
    duration: 10000,
  });
```
위와 같이 사용하시면 아래 디자인 된 message가 출력될 것입니다!
https://4x.ant.design/components/message/
**width,duration은 각자 style 속성으로 지정해주시길 바랍니다 ( message는 styledComponent로 하기 좀 힘들것 같은데 inline으로 할까요??)**
디자인 시스템에서는 message를 중앙 정렬하라고 나와있는데 중앙 정렬된 message가 컨텐츠를 가리는 느낌이고 좀 이상한 것 같아서 디자인팀에게 문의 드릴 예정입니다

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
https://testing-library.com/docs/queries/about/