### PR TITLE
Refactor: 숙소 등록 플로우 수정

### DIFF
--- a/src/pages/init-accommodation-registration/index.tsx
+++ b/src/pages/init-accommodation-registration/index.tsx
@@ -234,6 +234,7 @@ export const InitAccommodationRegistration = () => {
   };
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     if (
       accommodationData.isAccommodationEdit ||
       isClickedPrevButton ||

--- a/src/pages/init-info-confirmation/index.tsx
+++ b/src/pages/init-info-confirmation/index.tsx
@@ -20,6 +20,7 @@ export const InitInfoConfirmation = () => {
   );
 
   useEffect(() => {
+    window.scrollTo(0, 0);
     setUpdatedAccommodationInfo(true);
   }, []);
 

--- a/src/pages/init-room-registration/index.tsx
+++ b/src/pages/init-room-registration/index.tsx
@@ -68,6 +68,8 @@ export const InitRoomRegistration = () => {
   const [isAddRoom, setIsAddRoom] = useRecoilState(addRoomState);
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+
     if (
       userInputValue[0].editRoomIndex !== undefined &&
       userInputValue[0].editRoomIndex !== -1


### PR DESCRIPTION
### ⛳️ Task

### ✍️ Note
숙소 등록 플로우에서 각 페이지(숙소 등록, 객실 등록, 등록 정보 확인) 접속 시 스크롤 맨 위에 가있도록 설정했습니다.
각 페이지의 종속성 배열이 빈 배열인 useEffect에 window.scrollTo(0, 0); 코드만 추가했습니다

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
