### PR TITLE
Fix: 포인트 상세내역 조회 데이터바인딩 및 스타일 수정

### DIFF
--- a/src/components/point-detail/payment/common/coupon-info/index.tsx
+++ b/src/components/point-detail/payment/common/coupon-info/index.tsx
@@ -91,7 +91,7 @@ const CouponDetailBox = styled('div')`
 const FlexBox = styled('div')`
   display: flex;
   justify-content: space-between;
-
+  align-items: center;
   .margin-left {
     margin-left: 60px;
   }

--- a/src/components/point-detail/payment/common/order-point-info/index.tsx
+++ b/src/components/point-detail/payment/common/order-point-info/index.tsx
@@ -42,7 +42,7 @@ export const OrderPointInfo = ({
             : '결제 포인트'}
         </TextBox>
         <TextBox typography="body2" color={'primary'} fontWeight={'700'}>
-          {numberFormat(pointDetailData.histories[index].receipt.amount)} P
+          {numberFormat(pointDetailData.histories[index].amount)} P
         </TextBox>
       </OrderPointInfoList>
       <OrderPointInfoList>
@@ -50,7 +50,7 @@ export const OrderPointInfo = ({
           {isCancelStatus ? '환불 예정 금액' : '결제 금액'}
         </TextBox>
         <TextBox typography="body3" color={'black900'} fontWeight={'400'}>
-          {numberFormat(pointDetailData.histories[index].receipt.amount)} 원
+          {numberFormat(pointDetailData.histories[index].amount)} 원
         </TextBox>
       </OrderPointInfoList>
     </OrderPointInfoContainer>

--- a/src/components/point-detail/point-detail-list/index.tsx
+++ b/src/components/point-detail/point-detail-list/index.tsx
@@ -87,7 +87,7 @@ export const PointDetailList = () => {
             <StyledListItem>
               <TextBox typography="body2" color="black900" fontWeight="400">
                 {histories.type === '쿠폰'
-                  ? `${numberFormat(histories.trade)}매`
+                  ? `${numberFormat(histories.trade)}장`
                   : `${numberFormat(histories.trade)}원`}
               </TextBox>
             </StyledListItem>
@@ -100,7 +100,7 @@ export const PointDetailList = () => {
                 fontWeight="700"
               >
                 {histories.category === '사용' ? '-' : '+'}{' '}
-                {numberFormat(histories.trade)} P
+                {numberFormat(histories.amount)} P
               </TextBox>
             </StyledListItem>
             <StyledListItem>

--- a/src/stores/point-detail/atoms.ts
+++ b/src/stores/point-detail/atoms.ts
@@ -27,7 +27,7 @@ export const totalPagesState = atom({
 
 export const menuStatusState = atom<menuStatusType>({
   key: 'menuStatusState',
-  default: 'charges',
+  default: 'total',
 });
 
 export const pointSummaryDataState = atom<PointSummaryData>({


### PR DESCRIPTION
### ⛳️ Task

- [x] 포인트 상세내역 조회 데이터바인딩 및 스타일 수정
- [x] 포인트 API 전부다 연결후 확인.

### ✍️ Note

포인트 관련 모든 API 연결 후 작동까지 성공.

에러 사항.
1. 결제취소가 해당 포인트 충전할 때, 카드 결제만 되기때문에 해당 status를 백엔드에서 보내주고 버튼 Disabled 처리를 해야함
-> 해당 부분은 백엔드에서 현재 작업중.  -> 작업이 끝나면 해당 부분 수정 예정.

2. 포인트 상제 전체 조회 API에서 백엔드 데이터가 페이지에 맞게(4개)씩 주지 않고 전체 데이터로 불러오는 현상 -> 백엔드에서 현재 작업중. 

3. 포인트 사용 내역 (쿠폰 구매) 영수증에서 해당 부분이 중복되어져서 보내지는 현상 -> 백엔드에서 현재 작업중.

이렇게 총 3개가 있어서, 제가 고쳐야할 부분은 1번 부분이고 나머지 사항들은 백엔드에서 데이터가 잘 보내기만 한다면 제가 수정할 필요 없이 잘 진행이 될 것으로 예상이 됩니다.


### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
