### PR TITLE
Refactor: 숙소 등록 플로우 리팩토링

### DIFF
--- a/src/components/init/ButtonContainer.tsx
+++ b/src/components/init/ButtonContainer.tsx
@@ -28,9 +28,11 @@ export const ButtonContainer = ({
   const setIsClickPrev = useSetRecoilState(roomPrevButtonState);
 
   const handlePreviousClick = () => {
-    if (window.location.pathname === ROUTES.INIT_ACCOMMODATION_REGISTRATION)
-      navigate(-1);
-    else if (window.location.pathname === ROUTES.INIT_ROOM_REGISTRATION) {
+    if (window.location.pathname === ROUTES.INIT_ACCOMMODATION_REGISTRATION) {
+      const accommodationId = getCookie('accommodationId');
+      if (accommodationId) navigate(`/${accommodationId}${ROUTES.MAIN}`);
+      else navigate(ROUTES.INIT);
+    } else if (window.location.pathname === ROUTES.INIT_ROOM_REGISTRATION) {
       setIsClickPrev(true);
       navigate(ROUTES.INIT_ACCOMMODATION_REGISTRATION);
     }

--- a/src/components/init/ButtonContainer.tsx
+++ b/src/components/init/ButtonContainer.tsx
@@ -10,6 +10,7 @@ import { ROUTES } from '@/constants/routes';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import {
   isUpdatedAccommodationState,
+  isUpdatedRoomState,
   roomPrevButtonState,
   userInputValueState,
 } from '@stores/init/atoms';
@@ -41,6 +42,7 @@ export const ButtonContainer = ({
   const setIsUpdatedAccommodation = useSetRecoilState(
     isUpdatedAccommodationState,
   );
+  const setIsUpdatedRoom = useSetRecoilState(isUpdatedRoomState);
 
   const imageUrls: { url: string }[] = userInputValue[0].images.map(
     (image) => ({ url: image.url }),
@@ -73,6 +75,7 @@ export const ButtonContainer = ({
     onSuccess(data) {
       accommodationId = data.data.accommodationId;
       setIsUpdatedAccommodation(false);
+      setIsUpdatedRoom(false);
 
       const cookieAccommodationId = getCookie('accommodationId');
       if (!cookieAccommodationId) setCookie('accommodationId', accommodationId);

--- a/src/components/init/ButtonContainer.tsx
+++ b/src/components/init/ButtonContainer.tsx
@@ -111,7 +111,7 @@ export const ButtonContainer = ({
       if (error instanceof AxiosError) {
         message.error({
           content: '요청에 실패했습니다. 잠시 후 다시 시도해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
       if (
@@ -124,7 +124,7 @@ export const ButtonContainer = ({
       ) {
         message.error({
           content: '요청을 실패했습니다. 관리자에게 문의해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
       if (error.response?.data.code === RESPONSE_CODE.NOT_FOUND_MEMBER) {

--- a/src/components/init/CheckBoxContainer.tsx
+++ b/src/components/init/CheckBoxContainer.tsx
@@ -42,6 +42,27 @@ export const CheckBoxContainer = ({
     }
   }, [defaultValue]);
 
+  useEffect(() => {
+    return () => {
+      setSelectedInitRoomOptions({
+        airCondition: false,
+        tv: false,
+        internet: false,
+      });
+      setSelectedAccommodationOptions({
+        cooking: false,
+        parking: false,
+        pickup: false,
+        barbecue: false,
+        fitness: false,
+        karaoke: false,
+        sauna: false,
+        sports: false,
+        seminar: false,
+      });
+    };
+  }, []);
+
   const handleCheckboxChange = (event: CheckboxChangeEvent) => {
     const checkedOption = event.target.value;
 

--- a/src/components/init/ImageUploadContainer.tsx
+++ b/src/components/init/ImageUploadContainer.tsx
@@ -34,6 +34,12 @@ export const ImageUploadContainer = ({
     }
   }, [images]);
 
+  useEffect(() => {
+    return () => {
+      setImageFile([]);
+    };
+  }, []);
+
   const [imageFile, setImageFile] = useRecoilState(imageFileState);
   const setRemovedImageFile = useSetRecoilState(deletedImageFileState);
 

--- a/src/components/init/init-info-confirmation/RoomItem.tsx
+++ b/src/components/init/init-info-confirmation/RoomItem.tsx
@@ -38,7 +38,7 @@ export const RoomItem = () => {
     if (userInputValue[0].rooms.length === 1) {
       message.error({
         content: '최소 1개의 객실이 등록되어야 합니다.',
-        style: { marginTop: '210px' },
+        style: { marginTop: '64px' },
       });
       return;
     }
@@ -60,7 +60,7 @@ export const RoomItem = () => {
 
     message.success({
       content: '삭제되었습니다.',
-      style: { marginTop: '210px' },
+      style: { marginTop: '64px' },
     });
   };
 

--- a/src/constants/init/index.ts
+++ b/src/constants/init/index.ts
@@ -1,4 +1,4 @@
-export const NAME_REGEX = /[^ㄱ-ㅎ가-힣A-Za-z0-9\s]/g;
+export const NAME_REGEX = /[^ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9\s]/g;
 
 export const IMAGE_MAX_COUNT = 5;
 export const IMAGE_MAX_CAPACITY = 30;

--- a/src/pages/init-accommodation-registration/index.tsx
+++ b/src/pages/init-accommodation-registration/index.tsx
@@ -235,6 +235,7 @@ export const InitAccommodationRegistration = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
+
     if (
       accommodationData.isAccommodationEdit ||
       isClickedPrevButton ||
@@ -253,6 +254,9 @@ export const InitAccommodationRegistration = () => {
         options: userInputValue[0].options,
         type: userInputValue[0].type as defaultAccommodation['type'],
       });
+    }
+    if (updatedAccommodationInfo && userInputValue[0].rooms.length !== 0) {
+      navigate(ROUTES.INIT_INFO_CONFIRMATION);
     }
   }, []);
 

--- a/src/pages/init-accommodation-registration/index.tsx
+++ b/src/pages/init-accommodation-registration/index.tsx
@@ -137,13 +137,13 @@ export const InitAccommodationRegistration = () => {
       if (error instanceof AxiosError) {
         message.error({
           content: '요청에 실패했습니다. 잠시 후 다시 시도해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
       if (error.response?.data.code === RESPONSE_CODE.IMAGE_SAVE_FAIL) {
         message.error({
           content: '요청을 실패했습니다. 관리자에게 문의해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
     },

--- a/src/pages/init-accommodation-registration/index.tsx
+++ b/src/pages/init-accommodation-registration/index.tsx
@@ -255,7 +255,11 @@ export const InitAccommodationRegistration = () => {
         type: userInputValue[0].type as defaultAccommodation['type'],
       });
     }
-    if (updatedAccommodationInfo && userInputValue[0].rooms.length !== 0) {
+    if (
+      !accommodationData.isAccommodationEdit &&
+      updatedAccommodationInfo &&
+      userInputValue[0].rooms.length !== 0
+    ) {
       navigate(ROUTES.INIT_INFO_CONFIRMATION);
     }
   }, []);

--- a/src/pages/init-info-confirmation/index.tsx
+++ b/src/pages/init-info-confirmation/index.tsx
@@ -4,7 +4,9 @@ import { AccommodationInfo } from '@components/init/init-info-confirmation/Accom
 import { RoomInfo } from '@components/init/init-info-confirmation/RoomInfo';
 import { getCookie } from '@hooks/sign-in/useSignIn';
 import {
+  addRoomState,
   isUpdatedAccommodationState,
+  isUpdatedRoomState,
   userInputValueState,
 } from '@stores/init/atoms';
 import { useEffect } from 'react';
@@ -18,10 +20,14 @@ export const InitInfoConfirmation = () => {
   const setUpdatedAccommodationInfo = useSetRecoilState(
     isUpdatedAccommodationState,
   );
+  const setUpdatedRoomInfo = useSetRecoilState(isUpdatedRoomState);
+  const setIsAddRoomState = useSetRecoilState(addRoomState);
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    setIsAddRoomState(false);
     if (userInputValue[0].name !== '') setUpdatedAccommodationInfo(true);
+    if (userInputValue[0].rooms.length !== 0) setUpdatedRoomInfo(true);
   }, []);
 
   if (userInputValue[0].name === '') {

--- a/src/pages/init-info-confirmation/index.tsx
+++ b/src/pages/init-info-confirmation/index.tsx
@@ -21,7 +21,7 @@ export const InitInfoConfirmation = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    setUpdatedAccommodationInfo(true);
+    if (userInputValue[0].name !== '') setUpdatedAccommodationInfo(true);
   }, []);
 
   if (userInputValue[0].name === '') {

--- a/src/pages/init-room-registration/index.tsx
+++ b/src/pages/init-room-registration/index.tsx
@@ -189,13 +189,13 @@ export const InitRoomRegistration = () => {
       if (error instanceof AxiosError) {
         message.error({
           content: '요청에 실패했습니다. 잠시 후 다시 시도해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
       if (error.response?.data.code === RESPONSE_CODE.IMAGE_SAVE_FAIL) {
         message.error({
           content: '요청을 실패했습니다. 관리자에게 문의해주세요',
-          style: { marginTop: '210px' },
+          style: { marginTop: '64px' },
         });
       }
     },
@@ -221,7 +221,7 @@ export const InitRoomRegistration = () => {
       setSameRoomName(true);
       message.error({
         content: '동일한 객실명의 상품이 이미 존재합니다.',
-        style: { marginTop: '210px' },
+        style: { marginTop: '64px' },
       });
       window.scrollTo({ top: 0, behavior: 'smooth' });
       return;

--- a/src/pages/init-room-registration/index.tsx
+++ b/src/pages/init-room-registration/index.tsx
@@ -18,6 +18,7 @@ import {
   checkedRoomOptions,
   imageFileState,
   isUpdatedAccommodationState,
+  isUpdatedRoomState,
   userInputValueState,
 } from '@stores/init/atoms';
 import { capacityHasError, priceHasError } from '@stores/room/atoms';
@@ -67,11 +68,10 @@ export const InitRoomRegistration = () => {
 
   const [isAddRoom, setIsAddRoom] = useRecoilState(addRoomState);
 
+  const [isUpdatedRoom, setIsUpdatedRoom] = useRecoilState(isUpdatedRoomState);
+
   useEffect(() => {
     window.scrollTo(0, 0);
-    if (isUpdatedAccommodation && userInputValue[0].rooms.length !== 0) {
-      navigate(ROUTES.INIT_INFO_CONFIRMATION);
-    }
 
     if (
       userInputValue[0].editRoomIndex !== undefined &&
@@ -104,6 +104,14 @@ export const InitRoomRegistration = () => {
         images: userInputValue[0].rooms[index].images,
         options: userInputValue[0].rooms[index].options,
       });
+    } else if (
+      isUpdatedAccommodation &&
+      isUpdatedRoom &&
+      !isAddRoom &&
+      userInputValue[0].editRoomIndex === -1
+    ) {
+      navigate(ROUTES.INIT_INFO_CONFIRMATION);
+      setIsUpdatedRoom(false);
     }
   }, []);
 

--- a/src/pages/init-room-registration/index.tsx
+++ b/src/pages/init-room-registration/index.tsx
@@ -69,7 +69,7 @@ export const InitRoomRegistration = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    if (userInputValue[0].rooms.length !== 0) {
+    if (isUpdatedAccommodation && userInputValue[0].rooms.length !== 0) {
       navigate(ROUTES.INIT_INFO_CONFIRMATION);
     }
 

--- a/src/pages/init-room-registration/index.tsx
+++ b/src/pages/init-room-registration/index.tsx
@@ -69,6 +69,9 @@ export const InitRoomRegistration = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    if (userInputValue[0].rooms.length !== 0) {
+      navigate(ROUTES.INIT_INFO_CONFIRMATION);
+    }
 
     if (
       userInputValue[0].editRoomIndex !== undefined &&

--- a/src/stores/init/atoms.ts
+++ b/src/stores/init/atoms.ts
@@ -84,7 +84,7 @@ export const isUpdatedAccommodationState = atom({
   effects_UNSTABLE: [updateAccommodationPersist],
 });
 
-/** 객실 정보를 입력했는지 여부 */
+/** 객실 추가하기 버튼을 눌렀는지 여부 */
 const { persistAtom: addRoomPersist } = recoilPersist({
   key: 'addRoomState',
   storage: localStorage,

--- a/src/stores/init/atoms.ts
+++ b/src/stores/init/atoms.ts
@@ -84,6 +84,18 @@ export const isUpdatedAccommodationState = atom({
   effects_UNSTABLE: [updateAccommodationPersist],
 });
 
+/** 객실 정보를 입력했는지 여부 */
+const { persistAtom: updateRoomPersist } = recoilPersist({
+  key: 'isUpdatedRoomState',
+  storage: localStorage,
+});
+
+export const isUpdatedRoomState = atom({
+  key: 'isUpdatedRoom',
+  default: false,
+  effects_UNSTABLE: [updateRoomPersist],
+});
+
 /** 객실 추가하기 버튼을 눌렀는지 여부 */
 const { persistAtom: addRoomPersist } = recoilPersist({
   key: 'addRoomState',


### PR DESCRIPTION
### ⛳️ Task

### ✍️ Note
- 객실명/숙소명 컴포넌트가 현재 자음만 허용되고 있어서 통일성있게 그냥 모음까지 허용되도록 했습니다. (모음, 자음, 한글, 알파벳, 숫자 허용)

- 제 플로우에서 두 번째 헤더를 더 이상 fixed하지 않아서, toast의 위치를 변경해주기 위해 toast의 marginTop 속성 수치를 변경했습니다. (210px -> 64px)

- 객실이 하나라도 등록된 상태의 등록 확인 페이지에서 등록 요청을 누르지 않고 페이지를 나감 -> 사이드바에서 숙소 추가하기 버튼을 누름 -> 등록 확인 페이지로 이동

- 객실이 하나라도 등록된 상태의 등록 확인 페이지에서 등록 요청을 누르지 않고 페이지를 나감 -> 사용자가 url로 객실 등록 페이지 이동 -> 등록 확인 페이지로 이동

- 등록 확인 페이지를 렌더링하면 무조건 isAccommodationUpdated가 true가 되었었는데, (로컬스토리지에 아무것도 없는 상태일 때) 사용자가 url로 등록 확인 페이지에 들어감 -> url로 숙소 등록 페이지로 이동 -> 숙소 이미지 쪽에 깨진 이미지가 보이는 버그가 발생을 해서 로컬스토리지에 저장된 숙소 정보가 있을 때에만 setIsAccommodationUpdated를 해주는 코드를 추가하였습니다.

- 메인페이지 사이드바에서 숙소 추가 버튼 누름 -> 숙소 등록 페이지에서 정보 입력 -> 메인 페이지 이동(브라우저 뒤로가기 눌러서) -> 숙소 등록 페이지 이동시 이미지, 옵션이 초기화가 안되었던 버그를 수정했습니다.

- 이전 버튼 동작 수정

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
