### PR TITLE
Fix: 페이지네이션 사이드이펙트 해결, 날짜형식 변경,데이터 필드 method 추가.

### DIFF
--- a/src/api/point-detail/get-point-detail/type.ts
+++ b/src/api/point-detail/get-point-detail/type.ts
@@ -17,6 +17,7 @@ export type Receipt = {
   amount: string;
   accommodationName?: string;
   orders?: Orders[];
+  method?: string;
 };
 
 export type History = {

--- a/src/components/point-detail/page/index.tsx
+++ b/src/components/point-detail/page/index.tsx
@@ -1,11 +1,11 @@
 import { pageNumState, pointDetailDataState } from '@stores/point-detail/atoms';
 import { Pagination, Space } from 'antd';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import styled from 'styled-components';
 
 export const PageComp = () => {
-  const setPageNum = useSetRecoilState(pageNumState);
+  const [pageNum, setPageNum] = useRecoilState(pageNumState);
   const pointDetailData = useRecoilValue(pointDetailDataState);
 
   const handlePageChange = (pageNum: number) => {
@@ -15,7 +15,8 @@ export const PageComp = () => {
   return (
     <StyledSpace>
       <StyledPagination
-        defaultCurrent={1}
+        defaultCurrent={pageNum}
+        current={pageNum}
         total={pointDetailData.totalPages * 10}
         hideOnSinglePage={true}
         onChange={(page) => handlePageChange(page)}

--- a/src/components/point-detail/payment/common/order-info/index.tsx
+++ b/src/components/point-detail/payment/common/order-info/index.tsx
@@ -3,7 +3,6 @@ import { TextBox } from '@components/text-box';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { pointDetailDataState } from '@stores/point-detail/atoms';
-import { formatDate } from '@/utils/dateFormat/dateFormat';
 
 export const OrderInfo = ({ index }: { index: number }) => {
   const pointDetailData = useRecoilValue(pointDetailDataState);
@@ -15,12 +14,7 @@ export const OrderInfo = ({ index }: { index: number }) => {
       </TextBox>
 
       <TextBox typography="body2" color={'black900'} fontWeight={'700'}>
-        거래일시 :{' '}
-        {formatDate(
-          pointDetailData.histories[index].receipt.tradeAt.split('T')[0],
-        ).format1 +
-          ' ' +
-          pointDetailData.histories[index].receipt.tradeAt.split('T')[1]}
+        거래일시 : {pointDetailData.histories[index].receipt.tradeAt}
       </TextBox>
       {pointDetailData.histories[index].receipt.accommodationName && (
         <TextBox typography="body2" color={'black900'} fontWeight={'700'}>

--- a/src/components/point-detail/point-detail-list/index.tsx
+++ b/src/components/point-detail/point-detail-list/index.tsx
@@ -121,7 +121,12 @@ export const PointDetailList = () => {
               <div>
                 <StyledButton
                   isCancel={true}
-                  disabled={histories.status === '결제 완료' ? false : true}
+                  disabled={
+                    histories.status === '결제 완료' &&
+                    histories.receipt.method === '카드'
+                      ? false
+                      : true
+                  }
                   onClick={() => showCancelModal(index)}
                 >
                   결제 취소

--- a/src/components/point-detail/point-detail-menu/index.tsx
+++ b/src/components/point-detail/point-detail-menu/index.tsx
@@ -2,15 +2,17 @@ import { Button, Space } from 'antd';
 import styled from 'styled-components';
 
 import { colors } from '@/constants/colors';
-import { menuStatusState } from '@stores/point-detail/atoms';
-import { useRecoilState } from 'recoil';
+import { menuStatusState, pageNumState } from '@stores/point-detail/atoms';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { menuStatusType } from '@api/point-detail/get-point-detail/type';
 
 export const PointMenu = () => {
   const [menuStatus, setMenuStatus] = useRecoilState(menuStatusState);
+  const setPageNum = useSetRecoilState(pageNumState);
 
   const handleClickMenuButton = (status: menuStatusType) => {
     setMenuStatus(status);
+    setPageNum(1);
   };
 
   return (


### PR DESCRIPTION
### ⛳️ Task

Fix: 페이지네이션 사이드이펙트 해결, 날짜형식 변경, 데이터 필드 method 추가.

### ✍️ Note
Fix: 페이지네이션 사이드이펙트 해결, 날짜형식 변경

현재 포인트 상세 페이지에서 전체 조회 2페이지인 경우 사용이나 충전으로 가면 그대로 2페이지가 되어서 1페이지로 초기화 하는 코드를 추가했습니다.

날짜 형식이 백엔드에서 원시적인 형태로 주었는데, 해당 부분 백엔드에서 필터링 해준다고 하셔서 수정했습니다.

데이터 필드 method 추가.  -> 이제부터 토스 포인트 충전을 하면 해당 충전방식에 따라서 method에 값이 추가됩니다.

해당 타입이 카드인경우에만 결제 취소가 가능하고 나머지는 disabled 처리 했습니다.

기존에 있던 포인트 충전은 메소드가 '' 로 빈 스트링으로 되어있습니다.
### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
